### PR TITLE
Add a secret parameter

### DIFF
--- a/lib/fluent/plugin/out_hrforecast.rb
+++ b/lib/fluent/plugin/out_hrforecast.rb
@@ -34,7 +34,7 @@ class Fluent::HRForecastOutput < Fluent::Output
 
   config_param :authentication, :string, :default => nil # nil or 'none' or 'basic'
   config_param :username, :string, :default => ''
-  config_param :password, :string, :default => ''
+  config_param :password, :string, :default => '', :secret => true
 
   # Define `log` method for v0.10.42 or earlier
   unless method_defined?(:log)


### PR DESCRIPTION
In fluentd 0.12.11 or later supports secret parameter feature.
This feature works in log as below:

``` log
  <match metrics>
    type hrforecast
    hrfapi_url http://hrforecast.local/api/
    graph_path service/${tag}/${key_name}
    name_key_pattern ^field_(.*)$
    enable_float_number true
    datetime_key date_field
    datetime_key_format %Y/%m/%d
    datetime_format %Y-%m-%d %H:%M:%S
    authentication basic
    username hruser
    password xxxxxx
  </match>
</ROOT>
```
